### PR TITLE
Add ability to force candidates to be evaluated first

### DIFF
--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -173,3 +173,29 @@ def test_functions_executed_in_order():
 
     control_indexes = [run_experiment() for i in range(5)]
     assert set(control_indexes) == set([0])
+
+
+@pytest.mark.parametrize('randomize', [True, False])
+def test_candidates_first_executes_control_last(randomize):
+    num_candidates = 100
+
+    def run_experiment():
+        exp = laboratory.Experiment()
+
+        counter = {'index': 0}
+        def increment_counter():
+            counter['index'] += 1
+
+        def control_func():
+            return counter['index']
+
+        cand_func = mock.Mock(side_effect=increment_counter)
+
+        exp.control(control_func)
+        for _ in range(num_candidates):
+            exp.candidate(cand_func)
+
+        return exp.conduct(randomize=randomize, candidates_first=True)
+
+    control_indexes = [run_experiment() for i in range(5)]
+    assert set(control_indexes) == {num_candidates}

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -198,4 +198,4 @@ def test_candidates_first_executes_control_last(randomize):
         return exp.conduct(randomize=randomize, candidates_first=True)
 
     control_indexes = [run_experiment() for i in range(5)]
-    assert set(control_indexes) == {num_candidates}
+    assert set(control_indexes) == set([num_candidates])


### PR DESCRIPTION
If the control has side effects that cannot easily be isolated from candidates, then it can be useful to run the candidates before the control. It is easier to write new controls that do not have such side-effects.

This still respects the behaviour of randomize, the candidates will still be randomized and the control executed last if candidates_first is true.

Moving over from original PR on https://github.com/joealcorn/laboratory/pull/25 since it seems to have been abandoned.