### PR TITLE
Fix test incompatibility with Python 3.7 and bump travis versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,14 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.6-dev"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8-dev"
   - "nightly"
 
 matrix:
   allow_failures:
     - python: "nightly"
-    - python: "3.7-dev"
-    - python: "3.6-dev"
+    - python: "3.8-dev"
 
 script:
     # setuptools only supports py 3.3 up to version 39

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
     on_success: change
     on_failure: always
 
+dist: xenial
 language: python
 python:
   - "2.6"

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Testing',
         'Topic :: Utilities',
     ]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -117,9 +117,13 @@ def test_repr():
 
 
 def test_repr_with_exception():
+    exception = ValueError("something is wrong")
     obs = Observation("an observation")
-    obs.set_exception(ValueError("something is wrong"))
-    assert repr(obs) == """Observation(name='an observation', value=Unrecorded, exception=ValueError('something is wrong',))"""
+    obs.set_exception(exception)
+    expected_repr = "Observation(name='an observation', value=Unrecorded, exception={})".format(
+        repr(exception)
+    )
+    assert repr(obs) == expected_repr
 
 
 def test_functions_executed_in_random_order():


### PR DESCRIPTION
There was a trailing comma in the repr of ValueError exceptions prior to python 3.7. The removal of that is breaking tests under 3.7, so this updates the expected string to incorporate whatever the built-in repr for ValueError is.

Also bumps the python version in the travis config to the official 3.7 release, rather than dev, and disallows failures.

Moving over from original PR on https://github.com/joealcorn/laboratory/pull/26 since it seems to have been abandoned.